### PR TITLE
Working TX SLE

### DIFF
--- a/ADF7021.cpp
+++ b/ADF7021.cpp
@@ -34,6 +34,31 @@ volatile uint32_t  AD7021_control_word;
 uint32_t           ADF7021_RX_REG0;
 uint32_t           ADF7021_TX_REG0;
 
+volatile bool sle_request = false;
+
+static  void Send_AD7021_control_shift()
+{
+  int AD7021_counter;
+
+  for(AD7021_counter = 31; AD7021_counter >= 0; AD7021_counter--) {
+    if(bitRead(AD7021_control_word, AD7021_counter) == HIGH)
+      io.SDATA_pin(HIGH);
+    else
+      io.SDATA_pin(LOW);
+
+    io.dlybit();
+    io.SCLK_pin(HIGH);
+    io.dlybit();
+    io.SCLK_pin(LOW);
+  }
+}
+
+static  void Send_AD7021_control_nosle()
+{
+  Send_AD7021_control_shift();
+  sle_request = true;
+}
+
 void Send_AD7021_control()
 {
   int AD7021_counter;
@@ -391,7 +416,7 @@ void CIO::setTX()
 { 
   // Send register 0 for TX operation
   AD7021_control_word = ADF7021_TX_REG0;         
-  Send_AD7021_control();
+  Send_AD7021_control_nosle();
   
 #if defined(BIDIR_DATA_PIN)
   Data_dir_out(true);  // Data pin output mode

--- a/IO.h
+++ b/IO.h
@@ -55,6 +55,7 @@ public:
   void     SLE_pin(bool on);
   void     CE_pin(bool on);
   bool     RXD_pin(void);
+  bool     CLK_pin(void);
   
 #if defined(BIDIR_DATA_PIN)
   void     RXD_pin_write(bool on);

--- a/IOArduino.cpp
+++ b/IOArduino.cpp
@@ -171,17 +171,17 @@ void CIO::startInt()
 
 // TXD pin is TxRxCLK of ADF7021, standard TX/RX data interface
 #if defined (__STM32F1__)
-  attachInterrupt(PIN_TXD, EXT_IRQHandler, RISING);
+  attachInterrupt(PIN_TXD, EXT_IRQHandler, CHANGE);
 #else
-  attachInterrupt(digitalPinToInterrupt(PIN_TXD), EXT_IRQHandler, RISING);
+  attachInterrupt(digitalPinToInterrupt(PIN_TXD), EXT_IRQHandler, CHANGE);
 #endif
 
 #else
 
 #if defined (__STM32F1__)
-  attachInterrupt(PIN_CLKOUT, EXT_IRQHandler, RISING);
+  attachInterrupt(PIN_CLKOUT, EXT_IRQHandler, CHANGE);
 #else
-  attachInterrupt(digitalPinToInterrupt(PIN_CLKOUT), EXT_IRQHandler, RISING);
+  attachInterrupt(digitalPinToInterrupt(PIN_CLKOUT), EXT_IRQHandler, CHANGE);
 #endif
 
 #endif
@@ -228,6 +228,11 @@ bool CIO::RXD_pin()
   return digitalRead(PIN_RXD) == HIGH;
 }
 
+bool CIO::CLK_pin()
+{
+  return digitalRead(PIN_TXD) == HIGH;
+}
+
 #if defined(BIDIR_DATA_PIN)
 void CIO::RXD_pin_write(bool on)
 {
@@ -237,7 +242,11 @@ void CIO::RXD_pin_write(bool on)
 
 void CIO::TXD_pin(bool on) 
 {
+#if defined(BIDIR_DATA_PIN)
   digitalWrite(PIN_TXD, on ? HIGH : LOW);
+#else
+  digitalWrite(PIN_CLKOUT, on ? HIGH : LOW);
+#endif
 }
 
 void CIO::LED_pin(bool on) 

--- a/IOSTM.cpp
+++ b/IOSTM.cpp
@@ -440,7 +440,7 @@ void CIO::Init()
 #endif
 
   EXTI_InitStructure.EXTI_Mode = EXTI_Mode_Interrupt;
-  EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising;
+  EXTI_InitStructure.EXTI_Trigger = EXTI_Trigger_Rising_Falling;
   EXTI_InitStructure.EXTI_LineCmd = ENABLE;
   EXTI_Init(&EXTI_InitStructure);
 }
@@ -465,7 +465,7 @@ void CIO::startInt()
 
 #endif
 
-  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 15;
+  NVIC_InitStructure.NVIC_IRQChannelPreemptionPriority = 1;
   NVIC_InitStructure.NVIC_IRQChannelSubPriority = 15;
   NVIC_InitStructure.NVIC_IRQChannelCmd = ENABLE;
   NVIC_Init(&NVIC_InitStructure);
@@ -517,6 +517,15 @@ void CIO::CE_pin(bool on)
 bool CIO::RXD_pin()
 {
   return GPIO_ReadInputDataBit(PORT_RXD, PIN_RXD) == Bit_SET;
+}
+
+bool CIO::CLK_pin()
+{
+#if defined(BIDIR_DATA_PIN)
+  return GPIO_ReadInputDataBit(PORT_TXD, PIN_TXD) == Bit_SET;
+#else
+  return GPIO_ReadInputDataBit(PORT_CLKOUT, PIN_CLKOUT) == Bit_SET;
+#endif
 }
 
 #if defined(BIDIR_DATA_PIN)


### PR DESCRIPTION
tested with gcc 4.9.3 Ubuntu 16.10 (did not work before change, every second TX was lost)
tested also with gcc arm embedded 2016q4 on Ubuntu 16.10 (here original code worked as well)
tested also with gcc 4.8.4 on Raspbian Jessie  (here original code not tested)
Hardware STM32F103C8T6 STM32DUINO and RF7021SE wired together on breadboard.

MMDVMHost in all cases on Ubuntu 16.10

No test with Arduino IDE