### PR TITLE
Working baseline, …

### DIFF
--- a/ADF7021.cpp
+++ b/ADF7021.cpp
@@ -374,6 +374,7 @@ void CIO::ifConf(MMDVM_STATE modemState, bool reset)
   // Delay for coarse IF filter calibration
   delay_rx();
   delay_rx();
+  delay_rx();
 
   // Frequency RX (0)
   setRX();
@@ -429,9 +430,6 @@ void CIO::setTX()
 //======================================================================================================================
 void CIO::setRX()
 { 
-  // Delay for TX latency
-  delay_rx();
-  
   // Send register 0 for RX operation
   AD7021_control_word = ADF7021_RX_REG0;
   Send_AD7021_control();

--- a/IOArduino.cpp
+++ b/IOArduino.cpp
@@ -124,11 +124,6 @@ void CIO::delay_rx() {
 #endif
 }
 
-void CIO::dlybit(void)
-{
-  delayMicroseconds(1);
-}
-
 void CIO::Init()
 {
 #if defined (__STM32F1__)
@@ -287,6 +282,17 @@ void CIO::PTT_pin(bool on)
 void CIO::COS_pin(bool on) 
 {
   digitalWrite(PIN_COS_LED, on ? HIGH : LOW);
+}
+
+// TODO: Investigate why. In fact there is just a single place where this is being use
+// during normal operation
+#pragma GCC optimize ("O0")
+void CIO::dlybit(void)
+{
+    asm volatile("nop          \n\t"
+                 "nop          \n\t"
+                 "nop          \n\t"
+                 );
 }
 
 #endif

--- a/IOSTM.cpp
+++ b/IOSTM.cpp
@@ -17,6 +17,7 @@
  *   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
  */
 
+
 #include "Config.h"
 
 #if defined(STM32F10X_MD)
@@ -237,39 +238,6 @@ extern "C" {
 #endif
 
 #endif
-}
-
-/**
- * Function delay_us() from stm32duino project
- *
- * @brief Delay the given number of microseconds.
- *
- * @param us Number of microseconds to delay.
- */
-static inline void delay_us(uint32_t us) {
-    us *= 12;
-
-    /* fudge for function call overhead  */
-    us--;
-    asm volatile("   mov r0, %[us]          \n\t"
-                 "1: subs r0, #1            \n\t"
-                 "   bhi 1b                 \n\t"
-                 :
-                 : [us] "r" (us)
-                 : "r0");
-}
-
-void CIO::delay_rx() {
-#if defined(BIDIR_DATA_PIN)
-  delay_us(290);
-#else
-  delay_us(340);
-#endif
-}
-
-void CIO::dlybit(void)
-{
-  delay_us(1);
 }
 
 void CIO::Init()
@@ -532,6 +500,8 @@ bool CIO::CLK_pin()
 void CIO::RXD_pin_write(bool on)
 {
   GPIO_WriteBit(PORT_RXD, PIN_RXD, on ? Bit_SET : Bit_RESET);
+  GPIO_WriteBit(PORT_YSF_LED, PIN_YSF_LED, on ? Bit_SET : Bit_RESET);
+  GPIO_WriteBit(PORT_YSF_LED, PIN_YSF_LED, on ? Bit_SET : Bit_RESET);
 }
 #endif
 
@@ -580,4 +550,51 @@ void CIO::COS_pin(bool on)
   GPIO_WriteBit(PORT_COS_LED, PIN_COS_LED, on ? Bit_SET : Bit_RESET);
 }
 
+
+/**
+ * Function delay_us() from stm32duino project
+ *
+ * @brief Delay the given number of microseconds.
+ *
+ * @param us Number of microseconds to delay.
+ */
+static inline void delay_us(uint32_t us) {
+    us *= 12;
+
+    /* fudge for function call overhead  */
+    us--;
+    asm volatile("   mov r0, %[us]          \n\t"
+                 "1: subs r0, #1            \n\t"
+                 "   bhi 1b                 \n\t"
+                 :
+                 : [us] "r" (us)
+                 : "r0");
+}
+
+void CIO::delay_rx() {
+#if defined(BIDIR_DATA_PIN)
+  delay_us(290);
+#else
+  delay_us(340);
+#endif
+}
+
+
+// TODO: Investigate why. In fact there is just a single place where this is being use
+// during normal operation
+// it seems that optimizing this code breaks some timings
+#pragma GCC optimize ("O0")
+static inline void delay_ns() {
+
+    asm volatile("mov r8, r8          \n\t"
+                 "mov r8, r8          \n\t"
+                 "mov r8, r8          \n\t"
+                 );
+}
+
+
+void CIO::dlybit(void)
+{
+  delay_ns();
+}
 #endif

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,8 @@ A2L=arm-none-eabi-addr2line
 # Directory Structure
 BINDIR=bin
 
+OPTFLAG=-Os
+
 # Configure vars depending on OS
 ifeq ($(OS),Windows_NT)
 	ASOURCES=$(shell dir /S /B *.s)
@@ -116,9 +118,9 @@ LDFLAGS=$(MCFLAGS) --specs=nosys.specs $(INCLUDES_LIBS) $(LINK_LIBS)
 
 all: hs
 
-hs: CFLAGS+=$(DEFS_HS) -Os -ffunction-sections -fdata-sections -nostdlib
-hs: CXXFLAGS+=$(DEFS_HS) -Os -fno-exceptions -ffunction-sections -fdata-sections -nostdlib -fno-rtti
-hs: LDFLAGS+=-T $(LDSCRIPT_N) -Os --specs=nano.specs
+hs: CFLAGS+=$(DEFS_HS) $(OPTFLAG) -ffunction-sections -fdata-sections -nostdlib
+hs: CXXFLAGS+=$(DEFS_HS) $(OPTFLAG) -fno-exceptions -ffunction-sections -fdata-sections -nostdlib -fno-rtti
+hs: LDFLAGS+=-T $(LDSCRIPT_N) $(OPTFLAG) --specs=nano.specs
 hs: release
 
 bl: CFLAGS+=$(DEFS_HS_BL) -Os -ffunction-sections -fdata-sections -nostdlib


### PR DESCRIPTION
Anytime TX works with -O0 to -O3 with gcc 4.9.3 Ubuntu, Arduino gcc 4.8.3.
TX to RX switch timing is the challenge. This was causing the "lost" transmission. We now switch only after an even number of bits have been transmitted.
Had to exclude some delay routines from optimization, should make the whole AD7021 timing during normal operation completely agnostic to gcc optimization settings (up to the point where some process routines take too long time before passing on to the next process routine, of course).
However, due to vastly decreased serial comm for AD7021 register setting, no problem at all. Increased speed permits easy implementation of the proper RX / TX and TX / RX sequences (which makes the interrupt a tiny bit more complex).

Please try! 

 