### PR TITLE
All tested compilers  & make build now have proper timing for tx switching

### DIFF
--- a/ADF7021.h
+++ b/ADF7021.h
@@ -267,7 +267,7 @@ www.analog.com/media/en/technical-documentation/data-sheets/ADF7021.pdf
 
 #define bitRead(value, bit) (((value) >> (bit)) & 0x01)
 
-void Send_AD7021_control(void);
+void Send_AD7021_control(bool doSle = true);
 
 #endif
 

--- a/IO.h
+++ b/IO.h
@@ -90,7 +90,7 @@ public:
 
   // RF interface API
   void      setTX(void);
-  void      setRX(void);
+  void      setRX(bool doSle = true);
   void      ifConf(MMDVM_STATE modemState, bool reset);
   void      start(void);
   void      startInt(void);
@@ -102,6 +102,7 @@ public:
   // Misc functions
   void      dlybit(void);
   void      delay_rx(void);
+  void      delay_us(uint32_t us);
      
 private:
   

--- a/IOArduino.cpp
+++ b/IOArduino.cpp
@@ -280,9 +280,9 @@ void CIO::COS_pin(bool on)
   digitalWrite(PIN_COS_LED, on ? HIGH : LOW);
 }
 
-// TODO: Investigate why. In fact there is just a single place where this is being use
-// during normal operation
-#pragma GCC optimize ("O0")
+void CIO::delay_us(uint32_t us) {
+  ::delayMicroseconds(us);
+}
 void CIO::dlybit(void)
 {
     asm volatile("nop          \n\t"

--- a/IOSTM.cpp
+++ b/IOSTM.cpp
@@ -579,16 +579,15 @@ void CIO::delay_rx() {
 #endif
 }
 
+void CIO::delay_us(uint32_t us) {
+  ::delay_us(us);
+}
 
-// TODO: Investigate why. In fact there is just a single place where this is being use
-// during normal operation
-// it seems that optimizing this code breaks some timings
-#pragma GCC optimize ("O0")
 static inline void delay_ns() {
 
-    asm volatile("mov r8, r8          \n\t"
-                 "mov r8, r8          \n\t"
-                 "mov r8, r8          \n\t"
+    asm volatile("nop          \n\t"
+                 "nop          \n\t"
+                 "nop          \n\t"
                  );
 }
 


### PR DESCRIPTION
Tested with gcc 4.9.3, O0, Os (Ubuntu 16.10 stock), O3,  gcc 6.3. O0 2017q1 (Linux), O3, Arduino 4.8.3 Windows
Verified the timing using a logic analyzer.

This hopefully the final go at the tx rx switch challenge. Timing in previous commit was relying on the duration of ADF7021 control word sending, which varies largely (and takes a lot of time BTW). Now control word when switch to RX is sent out in main application code and only the activation is done in the interrupt (like when switching to TX). There is still variation across the compilers for the in-interrupt timing but much, much less so that we should have a reliable timing now which stays in the datasheet defined range.  Left a few comments in the crucial places. Needs some refactoring in order to be able to drive 2 or more ADF7021 independently (since the interrupt uses global variables for sync with application code, which should be handled inside the object, but this is a general issue in the current state of the ADF7021 code). 

Please test.