### PR TITLE
Serial repeater port changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,5 @@
 bin/
 
 GitVersion\.h
+
+STM32F10X_Lib/

--- a/Config.h
+++ b/Config.h
@@ -24,9 +24,7 @@
 // #define PI_HAT_7021_REV_02
 // 2) ZUM-Spot USB and ZUM-Spot Pi HAT:
 // #define PI_HAT_7021_REV_03
-// 3) ZUM-Spot Libre Kit
-// #define ZUMSPOT_LIBRE
-// 4) board with modified RF7021SE and Blue Pill STM32F103
+// 3) ZUM-Spot Libre Kit or board with modified RF7021SE and Blue Pill STM32F103
 #define ADF7021_CARRIER_BOARD
 
 // Enable ADF7021 support:
@@ -60,8 +58,10 @@
 // Send RSSI value:
 // #define SEND_RSSI_DATA
 
-// Enable Nextion LCD serial port repeater:
+// Enable Nextion LCD serial port repeater on USART2:
 // #define SERIAL_REPEATER
+// Enable Nextion LCD serial port repeater on USART1 (not compatible with ZUM-Spot Libre or STM32_USART1_HOST):
+// #define SERIAL_REPEATER_USART1
 
 // Enable P25 Wide modulation
 // #define ENABLE_P25_WIDE

--- a/Config.h
+++ b/Config.h
@@ -24,7 +24,9 @@
 // #define PI_HAT_7021_REV_02
 // 2) ZUM-Spot USB and ZUM-Spot Pi HAT:
 // #define PI_HAT_7021_REV_03
-// 3) ZUM-Spot Libre Kit or board with modified RF7021SE and Blue Pill STM32F103
+// 3) ZUM-Spot Libre Kit
+// #define ZUMSPOT_LIBRE
+// 4) board with modified RF7021SE and Blue Pill STM32F103
 #define ADF7021_CARRIER_BOARD
 
 // Enable ADF7021 support:

--- a/IOArduino.cpp
+++ b/IOArduino.cpp
@@ -65,7 +65,7 @@
 #define PIN_PTT_LED    PB14
 #define PIN_COS_LED    PB15
 
-#elif defined(ADF7021_CARRIER_BOARD)
+#elif defined(ADF7021_CARRIER_BOARD) || defined(ZUMSPOT_LIBRE)
 
 #define PIN_SCLK       PB5
 #define PIN_SREAD      PB7
@@ -85,7 +85,7 @@
 #define PIN_COS_LED    PB15
 
 #else
-#error "Either PI_HAT_7021_REV_02, PI_HAT_7021_REV_03, or ADF7021_CARRIER_BOARD need to be defined"
+#error "Either PI_HAT_7021_REV_02, PI_HAT_7021_REV_03, ZUMSPOT_LIBRE or ADF7021_CARRIER_BOARD need to be defined"
 #endif
 
 #elif defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
@@ -150,7 +150,7 @@ void CIO::Init()
 
 #if defined(PI_HAT_7021_REV_02)
   afio_cfg_debug_ports(AFIO_DEBUG_NONE);
-#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD)
+#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD) || defined(ZUMSPOT_LIBRE)
   afio_cfg_debug_ports(AFIO_DEBUG_SW_ONLY);
 #endif
 

--- a/IOArduino.cpp
+++ b/IOArduino.cpp
@@ -65,7 +65,7 @@
 #define PIN_PTT_LED    PB14
 #define PIN_COS_LED    PB15
 
-#elif defined(ADF7021_CARRIER_BOARD) || defined(ZUMSPOT_LIBRE)
+#elif defined(ADF7021_CARRIER_BOARD)
 
 #define PIN_SCLK       PB5
 #define PIN_SREAD      PB7
@@ -85,7 +85,7 @@
 #define PIN_COS_LED    PB15
 
 #else
-#error "Either PI_HAT_7021_REV_02, PI_HAT_7021_REV_03, ZUMSPOT_LIBRE or ADF7021_CARRIER_BOARD need to be defined"
+#error "Either PI_HAT_7021_REV_02, PI_HAT_7021_REV_03 or ADF7021_CARRIER_BOARD need to be defined"
 #endif
 
 #elif defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
@@ -150,7 +150,7 @@ void CIO::Init()
 
 #if defined(PI_HAT_7021_REV_02)
   afio_cfg_debug_ports(AFIO_DEBUG_NONE);
-#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD) || defined(ZUMSPOT_LIBRE)
+#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD)
   afio_cfg_debug_ports(AFIO_DEBUG_SW_ONLY);
 #endif
 

--- a/IOSTM.cpp
+++ b/IOSTM.cpp
@@ -139,7 +139,7 @@
 #define PIN_COS_LED          GPIO_Pin_15
 #define PORT_COS_LED         GPIOB
 
-#elif defined(ADF7021_CARRIER_BOARD)
+#elif defined(ADF7021_CARRIER_BOARD) || defined(ZUMSPOT_LIBRE)
 
 #define PIN_SCLK             GPIO_Pin_5
 #define PORT_SCLK            GPIOB
@@ -197,7 +197,7 @@
 #define PORT_COS_LED         GPIOB
 
 #else
-#error "Either PI_HAT_7021_REV_02, PI_HAT_7021_REV_03, or ADF7021_CARRIER_BOARD need to be defined"
+#error "Either PI_HAT_7021_REV_02, PI_HAT_7021_REV_03, ZUMSPOT_LIBRE or ADF7021_CARRIER_BOARD need to be defined"
 #endif
 
 extern "C" {
@@ -219,7 +219,7 @@ extern "C" {
   }
 #endif
 
-#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD)
+#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD) || defined(ZUMSPOT_LIBRE)
 
 #if defined(BIDIR_DATA_PIN)
   void EXTI3_IRQHandler(void) {
@@ -247,7 +247,7 @@ void CIO::Init()
   
 #if defined(PI_HAT_7021_REV_02)
   GPIO_PinRemapConfig(GPIO_Remap_SWJ_Disable, ENABLE);
-#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD)
+#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD) || defined(ZUMSPOT_LIBRE)
   GPIO_PinRemapConfig(GPIO_Remap_SWJ_JTAGDisable, ENABLE);
 #endif
 
@@ -391,7 +391,7 @@ void CIO::Init()
   EXTI_InitStructure.EXTI_Line = EXTI_Line14;
 #endif
 
-#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD)
+#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD) || defined(ZUMSPOT_LIBRE)
 
 #if defined(BIDIR_DATA_PIN)
   // Connect EXTI3 Line
@@ -421,7 +421,7 @@ void CIO::startInt()
 
   NVIC_InitStructure.NVIC_IRQChannel = EXTI15_10_IRQn;
 
-#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD)
+#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD) || defined(ZUMSPOT_LIBRE)
 
 #if defined(BIDIR_DATA_PIN)
   // Enable and set EXTI3 Interrupt

--- a/IOSTM.cpp
+++ b/IOSTM.cpp
@@ -139,7 +139,7 @@
 #define PIN_COS_LED          GPIO_Pin_15
 #define PORT_COS_LED         GPIOB
 
-#elif defined(ADF7021_CARRIER_BOARD) || defined(ZUMSPOT_LIBRE)
+#elif defined(ADF7021_CARRIER_BOARD)
 
 #define PIN_SCLK             GPIO_Pin_5
 #define PORT_SCLK            GPIOB
@@ -197,7 +197,7 @@
 #define PORT_COS_LED         GPIOB
 
 #else
-#error "Either PI_HAT_7021_REV_02, PI_HAT_7021_REV_03, ZUMSPOT_LIBRE or ADF7021_CARRIER_BOARD need to be defined"
+#error "Either PI_HAT_7021_REV_02, PI_HAT_7021_REV_03 or ADF7021_CARRIER_BOARD need to be defined"
 #endif
 
 extern "C" {
@@ -219,7 +219,7 @@ extern "C" {
   }
 #endif
 
-#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD) || defined(ZUMSPOT_LIBRE)
+#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD)
 
 #if defined(BIDIR_DATA_PIN)
   void EXTI3_IRQHandler(void) {
@@ -247,7 +247,7 @@ void CIO::Init()
   
 #if defined(PI_HAT_7021_REV_02)
   GPIO_PinRemapConfig(GPIO_Remap_SWJ_Disable, ENABLE);
-#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD) || defined(ZUMSPOT_LIBRE)
+#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD)
   GPIO_PinRemapConfig(GPIO_Remap_SWJ_JTAGDisable, ENABLE);
 #endif
 
@@ -391,7 +391,7 @@ void CIO::Init()
   EXTI_InitStructure.EXTI_Line = EXTI_Line14;
 #endif
 
-#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD) || defined(ZUMSPOT_LIBRE)
+#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD)
 
 #if defined(BIDIR_DATA_PIN)
   // Connect EXTI3 Line
@@ -421,7 +421,7 @@ void CIO::startInt()
 
   NVIC_InitStructure.NVIC_IRQChannel = EXTI15_10_IRQn;
 
-#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD) || defined(ZUMSPOT_LIBRE)
+#elif defined(PI_HAT_7021_REV_03) || defined(ADF7021_CARRIER_BOARD)
 
 #if defined(BIDIR_DATA_PIN)
   // Enable and set EXTI3 Interrupt

--- a/SerialSTM.cpp
+++ b/SerialSTM.cpp
@@ -44,7 +44,7 @@ USART2 - TXD PA2  - RXD PA3
 #define TX_SERIAL_FIFO_SIZE 256U
 #define RX_SERIAL_FIFO_SIZE 256U
 
-#if defined(STM32_USART1_HOST)
+#if defined(STM32_USART1_HOST) || defined(SERIAL_REPEATER)
 
 extern "C" {
   void USART1_IRQHandler();
@@ -439,9 +439,13 @@ void CSerialPort::beginInt(uint8_t n, int speed)
       usbserial.begin();
     #endif
       break;
-    #if defined(SERIAL_REPEATER)
+    #if defined(SERIAL_REPEATER) && (defined(STM32_USART1_HOST) || defined(ZUMSPOT_LIBRE))
     case 3U:
       InitUSART2(speed);
+      break;
+    #elif defined(SERIAL_REPEATER)
+    case 3U:
+      InitUSART1(speed);
       break;
     #endif
     default:
@@ -458,9 +462,12 @@ int CSerialPort::availableInt(uint8_t n)
     #elif defined(STM32_USB_HOST)
       return usbserial.available();
     #endif
-    #if defined(SERIAL_REPEATER)
+    #if defined(SERIAL_REPEATER) && (defined(STM32_USART1_HOST) || defined(ZUMSPOT_LIBRE))
     case 3U: 
       return AvailUSART2();
+    #elif defined(SERIAL_REPEATER)
+    case 3U: 
+      return AvailUSART1();
     #endif
     default:
       return 0;
@@ -476,9 +483,12 @@ uint8_t CSerialPort::readInt(uint8_t n)
     #elif defined(STM32_USB_HOST)
       return usbserial.read();
     #endif
-    #if defined(SERIAL_REPEATER)
+    #if defined(SERIAL_REPEATER) && (defined(STM32_USART1_HOST) || defined(ZUMSPOT_LIBRE))
     case 3U:
       return ReadUSART2();
+    #elif defined(SERIAL_REPEATER)
+    case 3U:
+      return ReadUSART1();
     #endif
     default:
       return 0U;
@@ -499,11 +509,17 @@ void CSerialPort::writeInt(uint8_t n, const uint8_t* data, uint16_t length, bool
         usbserial.flush();
     #endif
       break;
-    #if defined(SERIAL_REPEATER)
+    #if defined(SERIAL_REPEATER) && (defined(STM32_USART1_HOST) || defined(ZUMSPOT_LIBRE))
     case 3U:
       WriteUSART2(data, length);
       if (flush)
         TXSerialFlush2();
+      break;
+    #elif defined(SERIAL_REPEATER)
+    case 3U:
+      WriteUSART1(data, length);
+      if (flush)
+        TXSerialFlush1();
       break;
     #endif
     default:

--- a/SerialSTM.cpp
+++ b/SerialSTM.cpp
@@ -44,7 +44,7 @@ USART2 - TXD PA2  - RXD PA3
 #define TX_SERIAL_FIFO_SIZE 256U
 #define RX_SERIAL_FIFO_SIZE 256U
 
-#if defined(STM32_USART1_HOST) || defined(SERIAL_REPEATER)
+#if defined(STM32_USART1_HOST) || defined(SERIAL_REPEATER_USART1)
 
 extern "C" {
   void USART1_IRQHandler();
@@ -439,11 +439,11 @@ void CSerialPort::beginInt(uint8_t n, int speed)
       usbserial.begin();
     #endif
       break;
-    #if defined(SERIAL_REPEATER) && (defined(STM32_USART1_HOST) || defined(ZUMSPOT_LIBRE))
+    #if defined(SERIAL_REPEATER)
     case 3U:
       InitUSART2(speed);
       break;
-    #elif defined(SERIAL_REPEATER)
+    #elif defined(SERIAL_REPEATER_USART1)
     case 3U:
       InitUSART1(speed);
       break;
@@ -462,10 +462,10 @@ int CSerialPort::availableInt(uint8_t n)
     #elif defined(STM32_USB_HOST)
       return usbserial.available();
     #endif
-    #if defined(SERIAL_REPEATER) && (defined(STM32_USART1_HOST) || defined(ZUMSPOT_LIBRE))
+    #if defined(SERIAL_REPEATER)
     case 3U: 
       return AvailUSART2();
-    #elif defined(SERIAL_REPEATER)
+    #elif defined(SERIAL_REPEATER_USART1)
     case 3U: 
       return AvailUSART1();
     #endif
@@ -483,10 +483,10 @@ uint8_t CSerialPort::readInt(uint8_t n)
     #elif defined(STM32_USB_HOST)
       return usbserial.read();
     #endif
-    #if defined(SERIAL_REPEATER) && (defined(STM32_USART1_HOST) || defined(ZUMSPOT_LIBRE))
+    #if defined(SERIAL_REPEATER)
     case 3U:
       return ReadUSART2();
-    #elif defined(SERIAL_REPEATER)
+    #elif defined(SERIAL_REPEATER_USART1)
     case 3U:
       return ReadUSART1();
     #endif
@@ -509,13 +509,13 @@ void CSerialPort::writeInt(uint8_t n, const uint8_t* data, uint16_t length, bool
         usbserial.flush();
     #endif
       break;
-    #if defined(SERIAL_REPEATER) && (defined(STM32_USART1_HOST) || defined(ZUMSPOT_LIBRE))
+    #if defined(SERIAL_REPEATER)
     case 3U:
       WriteUSART2(data, length);
       if (flush)
         TXSerialFlush2();
       break;
-    #elif defined(SERIAL_REPEATER)
+    #elif defined(SERIAL_REPEATER_USART1)
     case 3U:
       WriteUSART1(data, length);
       if (flush)


### PR DESCRIPTION
Enables neater connection to erroneous boards with only 3 pins on USART2 like the one I have!

~~USART1 is now the default for Nextion serial repeater unless you define STM32_USART1_HOST or ZUMSPOT_LIBRE in Config.h~~

~~Needed to specify ZUMSPOT_LIBRE as separate board in Config.h as this only has a header for USART2 - Libre Kit will not use these changes.~~

~~All other boards appear to break out all USARTs in some form or other (specifically USART1)~~

~~EA7GIB's boards will now have a minor labelling error in that the header labelled Nextion (USART2) is no longer the Nextion port unless you define STM32_USART1_HOST or ZUMSPOT_LIBRE in Config.h.  If like me your OCD triggers with this, define ZUMSPOT_LIBRE and the nextion will be forced to USART2 (as labelled!)~~