### PR TITLE
Use DStar and DMR LEDs for POCSAG mode

### DIFF
--- a/IOArduino.cpp
+++ b/IOArduino.cpp
@@ -318,7 +318,10 @@ void CIO::NXDN_pin(bool on)
 
 void CIO::POCSAG_pin(bool on)
 {
-  // TODO: add a LED pin for POCSAG mode
+  // Use D-Star and DMR LED to indicate POCSAG mode
+  // TODO: add a separate LED pin for POCSAG mode
+  digitalWrite(PIN_DSTAR_LED, on ? HIGH : LOW);
+  digitalWrite(PIN_DMR_LED, on ? HIGH : LOW);
 }
 
 void CIO::PTT_pin(bool on) 

--- a/IOSTM.cpp
+++ b/IOSTM.cpp
@@ -649,7 +649,10 @@ void CIO::NXDN_pin(bool on)
 
 void CIO::POCSAG_pin(bool on)
 {
-  // TODO: add a LED pin for POCSAG mode
+  // Use D-Star and DMR LED to indicate POCSAG mode
+  // TODO: add a separate LED pin for POCSAG mode
+  GPIO_WriteBit(PORT_DSTAR_LED, PIN_DSTAR_LED, on ? Bit_SET : Bit_RESET);
+  GPIO_WriteBit(PORT_DMR_LED, PIN_DMR_LED, on ? Bit_SET : Bit_RESET);
 }
 
 void CIO::PTT_pin(bool on)


### PR DESCRIPTION
As a temporary fix and until we have boards with a separate POCSAG LED we can use D-Star and DMR LED simultaneously to indicate POCSAG mode.