### PR TITLE
Fix two compiler warnings about indentiation

### DIFF
--- a/DStarTX.cpp
+++ b/DStarTX.cpp
@@ -383,7 +383,7 @@ void CDStarTX::txHeader(const uint8_t* in, uint8_t* out) const
     if (i < 660U) {
       if (d & 0x08U)
         out[INTERLEAVE_TABLE_TX[i * 2U]] |= (0x01U << INTERLEAVE_TABLE_TX[i * 2U + 1U]);
-        i++;
+      i++;
 
       if (d & 0x04U)
         out[INTERLEAVE_TABLE_TX[i * 2U]] |= (0x01U << INTERLEAVE_TABLE_TX[i * 2U + 1U]);

--- a/SerialPort.cpp
+++ b/SerialPort.cpp
@@ -798,9 +798,10 @@ void CSerialPort::process()
 
           case MMDVM_POCSAG_DATA:
             if (m_pocsagEnable) {
-              if (m_modemState == STATE_IDLE || m_modemState == STATE_POCSAG)
+              if (m_modemState == STATE_IDLE || m_modemState == STATE_POCSAG) {
                 m_pocsag_state = true;
                 err = pocsagTX.writeData(m_buffer + 3U, m_len - 3U);
+              }
             }
             if (err == 0U) {
               if (m_modemState == STATE_IDLE)


### PR DESCRIPTION
Fix two compiler warnings:

```
SerialPort.cpp: In member function 'void CSerialPort::process()':
SerialPort.cpp:801:15: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
               if (m_modemState == STATE_IDLE || m_modemState == STATE_POCSAG)
               ^~
SerialPort.cpp:803:17: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
                 err = pocsagTX.writeData(m_buffer + 3U, m_len - 3U);
                 ^~~
```

and

```DStarTX.cpp: In member function 'void CDStarTX::txHeader(const uint8_t*, uint8_t*) const':
DStarTX.cpp:384:7: warning: this 'if' clause does not guard... [-Wmisleading-indentation]
       if (d & 0x08U)
       ^~
DStarTX.cpp:386:9: note: ...this statement, but the latter is misleadingly indented as if it is guarded by the 'if'
         i++;
         ^
```
