### PR TITLE
Summary: Add USART2 serial message processing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -421,46 +421,46 @@ stlink-bl-old:
 	$(ST_FLASH) write bin/$(BINBIN_F1BL) 0x8002000
 
 serial:
-	$(STM32FLASH) -v -w bin/$(BINBIN_F1) -g 0x0 $(devser)
+	$(STM32FLASH) -b 115200 -v -w bin/$(BINBIN_F1) -g 0x0 $(devser)
 
 serial-nobl:
-	$(STM32FLASH) -v -w bin/$(BINBIN_F1NOBL) -g 0x0 $(devser)
+	$(STM32FLASH) -b 115200 -v -w bin/$(BINBIN_F1NOBL) -g 0x0 $(devser)
 
 serial-bl:
-	$(STM32FLASH) -v -w $(F1_LIB_PATH)/utils/bootloader/generic_boot20_pc13_long_rst.bin -g 0x0 $(devser)
+	$(STM32FLASH) -b 115200 -v -w $(F1_LIB_PATH)/utils/bootloader/generic_boot20_pc13_long_rst.bin -g 0x0 $(devser)
 	sleep 3
-	$(STM32FLASH) -v -w bin/$(BINBIN_F1BL) -g 0x0 -S 0x08002000 $(devser)
+	$(STM32FLASH) -b 115200 -v -w bin/$(BINBIN_F1BL) -g 0x0 -S 0x08002000 $(devser)
 
 serial-bl-old:
-	$(STM32FLASH) -v -w $(F1_LIB_PATH)/utils/bootloader/generic_boot20_pc13.bin -g 0x0 $(devser)
+	$(STM32FLASH) -b 115200 -v -w $(F1_LIB_PATH)/utils/bootloader/generic_boot20_pc13.bin -g 0x0 $(devser)
 	sleep 3
-	$(STM32FLASH) -v -w bin/$(BINBIN_F1BL) -g 0x0 -S 0x08002000 $(devser)
+	$(STM32FLASH) -b 115200 -v -w bin/$(BINBIN_F1BL) -g 0x0 -S 0x08002000 $(devser)
 
 nano-hotspot:
 ifneq ($(wildcard /usr/local/bin/stm32flash),)
-	/usr/local/bin/stm32flash -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 200,-3,3:-200,3 /dev/ttyAMA0
+	/usr/local/bin/stm32flash -b 115200 -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 200,-3,3:-200,3 /dev/ttyAMA0
 endif
 
 ifneq ($(wildcard /usr/bin/stm32flash),)
-	/usr/bin/stm32flash -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 200,-3,3:-200,3 /dev/ttyAMA0
+	/usr/bin/stm32flash -b 115200 -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 200,-3,3:-200,3 /dev/ttyAMA0
 endif
 
 nano-dv:
 ifneq ($(wildcard /usr/local/bin/stm32flash),)
-	/usr/local/bin/stm32flash -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 66,-67,67:-66,67 /dev/ttyAMA0
+	/usr/local/bin/stm32flash -b 115200 -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 66,-67,67:-66,67 /dev/ttyAMA0
 endif
 
 ifneq ($(wildcard /usr/bin/stm32flash),)
-	/usr/bin/stm32flash -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 66,-67,67:-66,67 /dev/ttyAMA0
+	/usr/bin/stm32flash -b 115200 -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 66,-67,67:-66,67 /dev/ttyAMA0
 endif
 
 zumspot-pi:
 ifneq ($(wildcard /usr/local/bin/stm32flash),)
-	/usr/local/bin/stm32flash -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 20,-21,21:-20,21 /dev/ttyAMA0
+	/usr/local/bin/stm32flash -b 115200 -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 20,-21,21:-20,21 /dev/ttyAMA0
 endif
 
 ifneq ($(wildcard /usr/bin/stm32flash),)
-	/usr/bin/stm32flash -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 20,-21,21:-20,21 /dev/ttyAMA0
+	/usr/bin/stm32flash -b 115200 -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 20,-21,21:-20,21 /dev/ttyAMA0
 endif
 
 mmdvm_hs_hat: zumspot-pi

--- a/README.md
+++ b/README.md
@@ -262,11 +262,12 @@ Install the necessary software tools:
     sudo apt-get update
     sudo apt-get install gcc-arm-none-eabi gdb-arm-none-eabi libstdc++-arm-none-eabi-newlib libnewlib-arm-none-eabi
     
-    cd ~
-    git clone https://git.code.sf.net/p/stm32flash/code stm32flash
-    cd stm32flash
-    make
-    sudo make install
+Note: The Pi-Star image contains an executable for stm32flash. The next five steps can be skipped!
+#    cd ~
+#    git clone https://git.code.sf.net/p/stm32flash/code stm32flash
+#    cd stm32flash
+#    make
+#    sudo make install
 
 Download the firmware sources:
 

--- a/SerialPort.h
+++ b/SerialPort.h
@@ -30,6 +30,10 @@ public:
 
   void process();
 
+#if defined(SERIAL_REPEATER) || defined(SERIAL_REPEATER_USART1)
+  void writeSerialRpt(const uint8_t* data, uint8_t length);
+#endif
+
   void writeDStarHeader(const uint8_t* header, uint8_t length);
   void writeDStarData(const uint8_t* data, uint8_t length);
   void writeDStarLost();
@@ -65,6 +69,10 @@ private:
   uint8_t m_buffer[256U];
   uint8_t m_ptr;
   uint8_t m_len;
+  uint8_t m_serial_buffer[128U];
+  uint8_t m_serial_ptr;
+  uint8_t m_serial_len;
+
   bool    m_debug;
   bool    m_firstCal;
 

--- a/configs/MMDVM_HS_Dual_Hat-12mhz.h
+++ b/configs/MMDVM_HS_Dual_Hat-12mhz.h
@@ -71,6 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
+#define SERIAL_REPEATER_BAUD 115200
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/MMDVM_HS_Dual_Hat.h
+++ b/configs/MMDVM_HS_Dual_Hat.h
@@ -71,6 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
+#define SERIAL_REPEATER_BAUD 115200
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/MMDVM_HS_Hat-12mhz.h
+++ b/configs/MMDVM_HS_Hat-12mhz.h
@@ -71,6 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
+#define SERIAL_REPEATER_BAUD 115200
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/MMDVM_HS_Hat.h
+++ b/configs/MMDVM_HS_Hat.h
@@ -71,6 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
+#define SERIAL_REPEATER_BAUD 115200
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/NanoDV_NPI.h
+++ b/configs/NanoDV_NPI.h
@@ -71,6 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
+#define SERIAL_REPEATER_BAUD 115200
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/NanoDV_USB.h
+++ b/configs/NanoDV_USB.h
@@ -71,6 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
+#define SERIAL_REPEATER_BAUD 115200
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/Nano_hotSPOT.h
+++ b/configs/Nano_hotSPOT.h
@@ -71,6 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
+#define SERIAL_REPEATER_BAUD 115200
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/ZUMspot_Libre.h
+++ b/configs/ZUMspot_Libre.h
@@ -71,6 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
+#define SERIAL_REPEATER_BAUD 115200
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/ZUMspot_RPi.h
+++ b/configs/ZUMspot_RPi.h
@@ -71,6 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
+#define SERIAL_REPEATER_BAUD 115200
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/ZUMspot_duplex.h
+++ b/configs/ZUMspot_duplex.h
@@ -71,6 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
+#define SERIAL_REPEATER_BAUD 115200
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/generic_duplex_gpio.h
+++ b/configs/generic_duplex_gpio.h
@@ -71,6 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
+#define SERIAL_REPEATER_BAUD 115200
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/generic_gpio.h
+++ b/configs/generic_gpio.h
@@ -71,6 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
+#define SERIAL_REPEATER_BAUD 115200
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1


### PR DESCRIPTION
Description: 
1.  Update configs subdir files with high speed USART2 serial baud rate.  Update Makefile with high speed USART1 baud rate
2.  Implement Nextion serial message processing from USART2.  This allows the Nextion display to be connected to the Nextion port on the hotspot PCB (Modem board).  SerialPort.cpp and SerialPort.h updated.
Tested on Simplex ZumSpot-RPi using 3.4" Nextion display and PD0DIB's "Model 8 - 3.5inch_GLOBE-SIMPLEX_v1.2" screens, with two touch areas ('REBOOT' and 'POWEROFF').
3.  Update README.md.

Test:  RPi 3B+ running Pi-Star:4.0.0-RC3, with ZumSpot-Rpi running 1.4.16 (updated with these changes) and using ON7LDS Nextion driver.

Feel free to improve these changes for use with PD0DIB's Nextion display pages.