### PR TITLE
Summary: Change USART2 serial baud rate to 9600

### DIFF
--- a/Config.h
+++ b/Config.h
@@ -71,6 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
+#define SERIAL_REPEATER_BAUD 9600
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/Makefile
+++ b/Makefile
@@ -421,46 +421,46 @@ stlink-bl-old:
 	$(ST_FLASH) write bin/$(BINBIN_F1BL) 0x8002000
 
 serial:
-	$(STM32FLASH) -b 115200 -v -w bin/$(BINBIN_F1) -g 0x0 $(devser)
+	$(STM32FLASH) -v -w bin/$(BINBIN_F1) -g 0x0 $(devser)
 
 serial-nobl:
-	$(STM32FLASH) -b 115200 -v -w bin/$(BINBIN_F1NOBL) -g 0x0 $(devser)
+	$(STM32FLASH) -v -w bin/$(BINBIN_F1NOBL) -g 0x0 $(devser)
 
 serial-bl:
-	$(STM32FLASH) -b 115200 -v -w $(F1_LIB_PATH)/utils/bootloader/generic_boot20_pc13_long_rst.bin -g 0x0 $(devser)
+	$(STM32FLASH) -v -w $(F1_LIB_PATH)/utils/bootloader/generic_boot20_pc13_long_rst.bin -g 0x0 $(devser)
 	sleep 3
-	$(STM32FLASH) -b 115200 -v -w bin/$(BINBIN_F1BL) -g 0x0 -S 0x08002000 $(devser)
+	$(STM32FLASH) -v -w bin/$(BINBIN_F1BL) -g 0x0 -S 0x08002000 $(devser)
 
 serial-bl-old:
-	$(STM32FLASH) -b 115200 -v -w $(F1_LIB_PATH)/utils/bootloader/generic_boot20_pc13.bin -g 0x0 $(devser)
+	$(STM32FLASH) -v -w $(F1_LIB_PATH)/utils/bootloader/generic_boot20_pc13.bin -g 0x0 $(devser)
 	sleep 3
-	$(STM32FLASH) -b 115200 -v -w bin/$(BINBIN_F1BL) -g 0x0 -S 0x08002000 $(devser)
+	$(STM32FLASH) -v -w bin/$(BINBIN_F1BL) -g 0x0 -S 0x08002000 $(devser)
 
 nano-hotspot:
 ifneq ($(wildcard /usr/local/bin/stm32flash),)
-	/usr/local/bin/stm32flash -b 115200 -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 200,-3,3:-200,3 /dev/ttyAMA0
+	/usr/local/bin/stm32flash -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 200,-3,3:-200,3 /dev/ttyAMA0
 endif
 
 ifneq ($(wildcard /usr/bin/stm32flash),)
-	/usr/bin/stm32flash -b 115200 -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 200,-3,3:-200,3 /dev/ttyAMA0
+	/usr/bin/stm32flash -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 200,-3,3:-200,3 /dev/ttyAMA0
 endif
 
 nano-dv:
 ifneq ($(wildcard /usr/local/bin/stm32flash),)
-	/usr/local/bin/stm32flash -b 115200 -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 66,-67,67:-66,67 /dev/ttyAMA0
+	/usr/local/bin/stm32flash -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 66,-67,67:-66,67 /dev/ttyAMA0
 endif
 
 ifneq ($(wildcard /usr/bin/stm32flash),)
-	/usr/bin/stm32flash -b 115200 -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 66,-67,67:-66,67 /dev/ttyAMA0
+	/usr/bin/stm32flash -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 66,-67,67:-66,67 /dev/ttyAMA0
 endif
 
 zumspot-pi:
 ifneq ($(wildcard /usr/local/bin/stm32flash),)
-	/usr/local/bin/stm32flash -b 115200 -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 20,-21,21:-20,21 /dev/ttyAMA0
+	/usr/local/bin/stm32flash -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 20,-21,21:-20,21 /dev/ttyAMA0
 endif
 
 ifneq ($(wildcard /usr/bin/stm32flash),)
-	/usr/bin/stm32flash -b 115200 -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 20,-21,21:-20,21 /dev/ttyAMA0
+	/usr/bin/stm32flash -v -w bin/$(BINBIN_F1) -g 0x0 -R -i 20,-21,21:-20,21 /dev/ttyAMA0
 endif
 
 mmdvm_hs_hat: zumspot-pi

--- a/configs/MMDVM_HS_Dual_Hat-12mhz.h
+++ b/configs/MMDVM_HS_Dual_Hat-12mhz.h
@@ -71,7 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
-#define SERIAL_REPEATER_BAUD 115200
+#define SERIAL_REPEATER_BAUD 9600
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/MMDVM_HS_Dual_Hat.h
+++ b/configs/MMDVM_HS_Dual_Hat.h
@@ -71,7 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
-#define SERIAL_REPEATER_BAUD 115200
+#define SERIAL_REPEATER_BAUD 9600
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/MMDVM_HS_Hat-12mhz.h
+++ b/configs/MMDVM_HS_Hat-12mhz.h
@@ -71,7 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
-#define SERIAL_REPEATER_BAUD 115200
+#define SERIAL_REPEATER_BAUD 9600
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/MMDVM_HS_Hat.h
+++ b/configs/MMDVM_HS_Hat.h
@@ -71,7 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
-#define SERIAL_REPEATER_BAUD 115200
+#define SERIAL_REPEATER_BAUD 9600
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/NanoDV_NPI.h
+++ b/configs/NanoDV_NPI.h
@@ -71,7 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
-#define SERIAL_REPEATER_BAUD 115200
+#define SERIAL_REPEATER_BAUD 9600
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/NanoDV_USB.h
+++ b/configs/NanoDV_USB.h
@@ -71,7 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
-#define SERIAL_REPEATER_BAUD 115200
+#define SERIAL_REPEATER_BAUD 9600
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/Nano_hotSPOT.h
+++ b/configs/Nano_hotSPOT.h
@@ -71,7 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
-#define SERIAL_REPEATER_BAUD 115200
+#define SERIAL_REPEATER_BAUD 9600
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/ZUMspot_Libre.h
+++ b/configs/ZUMspot_Libre.h
@@ -71,7 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
-#define SERIAL_REPEATER_BAUD 115200
+#define SERIAL_REPEATER_BAUD 9600
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/ZUMspot_RPi.h
+++ b/configs/ZUMspot_RPi.h
@@ -71,7 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
-#define SERIAL_REPEATER_BAUD 115200
+#define SERIAL_REPEATER_BAUD 9600
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/ZUMspot_duplex.h
+++ b/configs/ZUMspot_duplex.h
@@ -71,7 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
-#define SERIAL_REPEATER_BAUD 115200
+#define SERIAL_REPEATER_BAUD 9600
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/generic_duplex_gpio.h
+++ b/configs/generic_duplex_gpio.h
@@ -71,7 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
-#define SERIAL_REPEATER_BAUD 115200
+#define SERIAL_REPEATER_BAUD 9600
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/configs/generic_gpio.h
+++ b/configs/generic_gpio.h
@@ -71,7 +71,7 @@
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
 #define SERIAL_REPEATER
-#define SERIAL_REPEATER_BAUD 115200
+#define SERIAL_REPEATER_BAUD 9600
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1


### PR DESCRIPTION
Description: 
Andy, I apologize for these changes.  My son and I submitted high serial baud rates and then figured out most users will be using 9600, so it is best to stick with it. We didn't have any issues running at 115200.
1.  Update configs subdir files with USART2 serial baud rate of 9600.  Update Makefile - remove high speed USART1 baud rate compile flag.
2.  I used 'Compare-it' to diff the files and these files should closely match your original files (minimal changes from originals).
3.  Thanks for all your work on the MMDVM code!  I have been a ham since 1977 and just found DMR and hotspots.  Amazing technology in use these days. 

Feel free to improve these changes for use with PD0DIB's Nextion display pages.

Garry / WD0DUD