### PR TITLE
Detect full 48 bits of last data frame in a D-Star transmission

### DIFF
--- a/DStarRX.cpp
+++ b/DStarRX.cpp
@@ -1,5 +1,5 @@
 /*
- *   Copyright (C) 2009-2016 by Jonathan Naylor G4KLX
+ *   Copyright (C) 2009-2016,2020 by Jonathan Naylor G4KLX
  *   Copyright (C) 2016,2017,2018 by Andy Uribe CA6JAU
  *
  *   This program is free software; you can redistribute it and/or modify
@@ -25,18 +25,18 @@
 const unsigned int MAX_SYNC_BITS = 100U * DSTAR_DATA_LENGTH_BITS;
 
 // D-Star preamble sequence (only 32 bits of 101010...)
-const uint32_t PREAMBLE_MASK = 0xFFFFFFFFU;
-const uint32_t PREAMBLE_DATA = 0xAAAAAAAAU;
+const uint64_t PREAMBLE_MASK = 0x00000000FFFFFFFFU;
+const uint64_t PREAMBLE_DATA = 0x00000000AAAAAAAAU;
 const uint8_t  PREAMBLE_ERRS = 2U;
 
 // D-Star bit order version of 0x55 0x55 0x6E 0x0A
-const uint32_t FRAME_SYNC_DATA = 0x00557650U;
-const uint32_t FRAME_SYNC_MASK = 0x00FFFFFFU;
+const uint64_t FRAME_SYNC_DATA = 0x0000000000557650U;
+const uint64_t FRAME_SYNC_MASK = 0x0000000000FFFFFFU;
 const uint8_t  FRAME_SYNC_ERRS = 2U;
 
 // D-Star bit order version of 0x55 0x2D 0x16
-const uint32_t DATA_SYNC_DATA = 0x00AAB468U;
-const uint32_t DATA_SYNC_MASK = 0x00FFFFFFU;
+const uint64_t DATA_SYNC_DATA = 0x0000000000AAB468U;
+const uint64_t DATA_SYNC_MASK = 0x0000000000FFFFFFU;
 const uint8_t  DATA_SYNC_ERRS = 3U;
 
 // D-Star bit order version of 0x55 0x55 0xC8 0x7A
@@ -239,7 +239,6 @@ const uint16_t CCITT_TABLE[] = {
 CDStarRX::CDStarRX() :
 m_rxState(DSRXS_NONE),
 m_patternBuffer(0x00U),
-m_patternBuffer64(0x00U),
 m_rxBuffer(),
 m_rxBufferBits(0U),
 m_dataBits(0U),
@@ -257,7 +256,6 @@ void CDStarRX::reset()
 {
   m_rxState       = DSRXS_NONE;
   m_patternBuffer = 0x00U;
-  m_patternBuffer64 = 0x00U;
   m_rxBufferBits  = 0U;
   m_dataBits      = 0U;
 }
@@ -285,12 +283,8 @@ void CDStarRX::processNone(bool bit)
   if (bit)
     m_patternBuffer |= 0x01U;
 
-  m_patternBuffer64 <<= 1;
-  if (bit)
-    m_patternBuffer64 |= 0x01U;
-
   // Fuzzy matching of the preamble sync sequence
-  if (countBits32((m_patternBuffer & PREAMBLE_MASK) ^ PREAMBLE_DATA) <= PREAMBLE_ERRS) {
+  if (countBits64((m_patternBuffer & PREAMBLE_MASK) ^ PREAMBLE_DATA) <= PREAMBLE_ERRS) {
 
     // Extend scan period in D-Star, once preamble is detected
     m_modeTimerCnt = 0;
@@ -301,7 +295,7 @@ void CDStarRX::processNone(bool bit)
   }
 
   // Fuzzy matching of the frame sync sequence
-  if (countBits32((m_patternBuffer & FRAME_SYNC_MASK) ^ FRAME_SYNC_DATA) <= FRAME_SYNC_ERRS) {
+  if (countBits64((m_patternBuffer & FRAME_SYNC_MASK) ^ FRAME_SYNC_DATA) <= FRAME_SYNC_ERRS) {
     DEBUG1("DStarRX: found frame sync in None, fuzzy");
 
     ::memset(m_rxBuffer, 0x00U, DSTAR_FEC_SECTION_LENGTH_BYTES);
@@ -312,7 +306,7 @@ void CDStarRX::processNone(bool bit)
   }
 
   // Exact matching of the data sync bit sequence
-  if (countBits32((m_patternBuffer & DATA_SYNC_MASK) ^ DATA_SYNC_DATA) == 0U) {
+  if (countBits64((m_patternBuffer & DATA_SYNC_MASK) ^ DATA_SYNC_DATA) == 0U) {
     DEBUG1("DStarRX: found data sync in None, exact");
 
     io.setDecode(true);
@@ -334,10 +328,6 @@ void CDStarRX::processHeader(bool bit)
   m_patternBuffer <<= 1;
   if (bit)
     m_patternBuffer |= 0x01U;
-
-  m_patternBuffer64 <<= 1;
-  if (bit)
-    m_patternBuffer64 |= 0x01U;
 
   WRITE_BIT2(m_rxBuffer, m_rxBufferBits, bit);
 
@@ -373,10 +363,6 @@ void CDStarRX::processData(bool bit)
   if (bit)
     m_patternBuffer |= 0x01U;
 
-  m_patternBuffer64 <<= 1;
-  if (bit)
-    m_patternBuffer64 |= 0x01U;
-
   WRITE_BIT2(m_rxBuffer, m_rxBufferBits, bit);
 
   m_rxBufferBits++;
@@ -384,7 +370,7 @@ void CDStarRX::processData(bool bit)
     reset();
 
   // Fuzzy matching of the end frame sequences
-  if (countBits64((m_patternBuffer64 & END_SYNC_MASK) ^ END_SYNC_DATA) <= END_SYNC_ERRS) {
+  if (countBits64((m_patternBuffer & END_SYNC_MASK) ^ END_SYNC_DATA) <= END_SYNC_ERRS) {
     DEBUG1("DStarRX: Found end sync in Data");
     io.setDecode(false);
 
@@ -397,7 +383,7 @@ void CDStarRX::processData(bool bit)
   // Fuzzy matching of the data sync bit sequence
   bool syncSeen = false;
   if (m_rxBufferBits >= (DSTAR_DATA_LENGTH_BITS - 3U)) {
-    if (countBits32((m_patternBuffer & DATA_SYNC_MASK) ^ DATA_SYNC_DATA) <= DATA_SYNC_ERRS) {
+    if (countBits64((m_patternBuffer & DATA_SYNC_MASK) ^ DATA_SYNC_DATA) <= DATA_SYNC_ERRS) {
       m_rxBufferBits = DSTAR_DATA_LENGTH_BITS;
       m_dataBits     = MAX_SYNC_BITS;
       syncSeen       = true;
@@ -407,9 +393,9 @@ void CDStarRX::processData(bool bit)
   // Check to see if the sync is arriving late
   if (m_rxBufferBits == DSTAR_DATA_LENGTH_BITS && !syncSeen) {
     for (uint8_t i = 1U; i <= 3U; i++) {
-      uint32_t syncMask = DATA_SYNC_MASK >> i;
-      uint32_t syncData = DATA_SYNC_DATA >> i;
-      if (countBits32((m_patternBuffer & syncMask) ^ syncData) <= DATA_SYNC_ERRS) {
+      uint64_t syncMask = DATA_SYNC_MASK >> i;
+      uint64_t syncData = DATA_SYNC_DATA >> i;
+      if (countBits64((m_patternBuffer & syncMask) ^ syncData) <= DATA_SYNC_ERRS) {
         m_rxBufferBits -= i;
         break;
       }

--- a/DStarRX.h
+++ b/DStarRX.h
@@ -1,5 +1,5 @@
 /*
- *   Copyright (C) 2015,2016 by Jonathan Naylor G4KLX
+ *   Copyright (C) 2015,2016,2020 by Jonathan Naylor G4KLX
  *   Copyright (C) 2016,2017 by Andy Uribe CA6JAU
  *
  *   This program is free software; you can redistribute it and/or modify
@@ -40,8 +40,7 @@ public:
 
 private:
   DSRX_STATE   m_rxState;
-  uint32_t     m_patternBuffer;
-  uint64_t     m_patternBuffer64;
+  uint64_t     m_patternBuffer;
   uint8_t      m_rxBuffer[DSTAR_BUFFER_LENGTH_BITS / 8U];
   unsigned int m_rxBufferBits;
   unsigned int m_dataBits;

--- a/DStarRX.h
+++ b/DStarRX.h
@@ -41,6 +41,7 @@ public:
 private:
   DSRX_STATE   m_rxState;
   uint32_t     m_patternBuffer;
+  uint64_t     m_patternBuffer64;
   uint8_t      m_rxBuffer[DSTAR_BUFFER_LENGTH_BITS / 8U];
   unsigned int m_rxBufferBits;
   unsigned int m_dataBits;


### PR DESCRIPTION
While testing new support for DV Fast Data in g4klx/MMDVMHost#667, I ran across a particular image that reliably generated a bit sequence that the MDMVM firmware interpreted as an end-of-transmission. I dug a bit and discovered that MMDVM only matches on 32 bits of the last data frame instead of the full 48 bits.

(I referenced http://www.arrl.org/files/file/D-STAR.pdf section 2.1.2, item (6))

I tested this patch on my ZUMSpot, a on Raspberry Pi with a ZUM Radio MMDVM-Pi rev 1.0 board (using the MMDVM version of this PR at https://github.com/g4klx/MMDVM/pull/306), and the test image no longer generated an early EOT on either system.

A second commit 08a6c21 is the follow-up work that @g4klx did in https://github.com/g4klx/MMDVM, which I've included in this PR.