### PR TITLE
Add support for LoneStar USB Stick

### DIFF
--- a/IO.cpp
+++ b/IO.cpp
@@ -318,7 +318,7 @@ bool CIO::hasRXOverflow()
   return m_rxBuffer.hasOverflowed();
 }
 
-#if defined(ZUMSPOT_ADF7021) || defined(SKYBRIDGE_HS)
+#if defined(ZUMSPOT_ADF7021) || defined(LONESTAR_USB) || defined(SKYBRIDGE_HS)
 void CIO::checkBand(uint32_t frequency_rx, uint32_t frequency_tx) {
   if (!(io.hasSingleADF7021())) {
     // There are two ADF7021s on the board
@@ -391,7 +391,7 @@ uint8_t CIO::setFreq(uint32_t frequency_rx, uint32_t frequency_tx, uint8_t rf_po
 #endif
 
 // Check if we have a single, dualband or duplex board
-#if defined(ZUMSPOT_ADF7021) || defined(SKYBRIDGE_HS)
+#if defined(ZUMSPOT_ADF7021) || defined(LONESTAR_USB) || defined(SKYBRIDGE_HS)
   if (checkZUMspot(frequency_rx, frequency_tx) > 0) {
     return 4U;
   }

--- a/IO.h
+++ b/IO.h
@@ -125,7 +125,7 @@ public:
   uint32_t  getWatchdog(void);
   void      getIntCounter(uint16_t &int1, uint16_t &int2);
   void      selfTest(void);
-#if defined(ZUMSPOT_ADF7021) || defined(SKYBRIDGE_HS)
+#if defined(ZUMSPOT_ADF7021) || defined(LONESTAR_USB) || defined(SKYBRIDGE_HS)
   void      checkBand(uint32_t frequency_rx, uint32_t frequency_tx);
   uint8_t   checkZUMspot(uint32_t frequency_rx, uint32_t frequency_tx);
   void      setBandVHF(bool vhf_on);

--- a/IOArduino.cpp
+++ b/IOArduino.cpp
@@ -28,7 +28,7 @@
 
 // STM32F1 pin definitions, using STM32duino
 
-#if defined(ZUMSPOT_ADF7021) || defined(SKYBRIDGE_HS)
+#if defined(ZUMSPOT_ADF7021) || defined(LONESTAR_USB) || defined(SKYBRIDGE_HS)
 
 #define PIN_SCLK       PB5
 #define PIN_SREAD      PB6
@@ -81,7 +81,7 @@
 #define PIN_COS_LED    PB15
 
 #else
-#error "Either ZUMSPOT_ADF7021, LIBRE_KIT_ADF7021, MMDVM_HS_HAT_REV12, MMDVM_HS_DUAL_HAT_REV10, NANO_HOTSPOT, NANO_DV_REV10 or SKYBRIDGE_HS need to be defined"
+#error "Either ZUMSPOT_ADF7021, LONESTAR_USB, LIBRE_KIT_ADF7021, MMDVM_HS_HAT_REV12, MMDVM_HS_DUAL_HAT_REV10, NANO_HOTSPOT, NANO_DV_REV10 or SKYBRIDGE_HS need to be defined"
 #endif
 
 #elif defined(__MK20DX256__) || defined(__MK64FX512__) || defined(__MK66FX1M0__)
@@ -156,7 +156,7 @@ void CIO::Init()
 {
 #if defined (__STM32F1__)
 
-#if defined(ZUMSPOT_ADF7021) || defined(LIBRE_KIT_ADF7021) || defined(MMDVM_HS_HAT_REV12) || defined(MMDVM_HS_DUAL_HAT_REV10) || defined(NANO_HOTSPOT) || defined(NANO_DV_REV10) || defined(SKYBRIDGE_HS)
+#if defined(ZUMSPOT_ADF7021) || defined(LONESTAR_USB) || defined(LIBRE_KIT_ADF7021) || defined(MMDVM_HS_HAT_REV12) || defined(MMDVM_HS_DUAL_HAT_REV10) || defined(NANO_HOTSPOT) || defined(NANO_DV_REV10) || defined(SKYBRIDGE_HS)
   afio_cfg_debug_ports(AFIO_DEBUG_SW_ONLY);
 #endif
 

--- a/IOSTM.cpp
+++ b/IOSTM.cpp
@@ -97,7 +97,7 @@
 #define PIN_COS_LED          GPIO_Pin_13
 #define PORT_COS_LED         GPIOB
 
-#elif defined(ZUMSPOT_ADF7021) || defined(SKYBRIDGE_HS)
+#elif defined(ZUMSPOT_ADF7021) || defined(SKYBRIDGE_HS) || defined(LONESTAR_USB)
 
 #define PIN_SCLK             GPIO_Pin_5
 #define PORT_SCLK            GPIOB
@@ -275,7 +275,7 @@
 #define PORT_COS_LED         GPIOB
 
 #else
-#error "Either PI_HAT_7021_REV_02, ZUMSPOT_ADF7021, LIBRE_KIT_ADF7021, MMDVM_HS_HAT_REV12, MMDVM_HS_DUAL_HAT_REV10, NANO_HOTSPOT, NANO_DV_REV11, D2RG_MMDVM_HS or SKYBRIDGE_HS need to be defined"
+#error "Either PI_HAT_7021_REV_02, ZUMSPOT_ADF7021, LONESTAR_USB, LIBRE_KIT_ADF7021, MMDVM_HS_HAT_REV12, MMDVM_HS_DUAL_HAT_REV10, NANO_HOTSPOT, NANO_DV_REV11, D2RG_MMDVM_HS or SKYBRIDGE_HS need to be defined"
 #endif
 
 extern "C" {
@@ -297,7 +297,7 @@ extern "C" {
   }
 #endif
 
-#elif defined(ZUMSPOT_ADF7021) || defined(LIBRE_KIT_ADF7021) || defined(MMDVM_HS_HAT_REV12) || defined(MMDVM_HS_DUAL_HAT_REV10) || defined(NANO_HOTSPOT) || defined(NANO_DV_REV11) || defined(D2RG_MMDVM_HS) || defined(SKYBRIDGE_HS)
+#elif defined(ZUMSPOT_ADF7021) || defined(LONESTAR_USB) || defined(LIBRE_KIT_ADF7021) || defined(MMDVM_HS_HAT_REV12) || defined(MMDVM_HS_DUAL_HAT_REV10) || defined(NANO_HOTSPOT) || defined(NANO_DV_REV11) || defined(D2RG_MMDVM_HS) || defined(SKYBRIDGE_HS)
 
 #if defined(BIDIR_DATA_PIN)
   void EXTI3_IRQHandler(void) {
@@ -348,11 +348,11 @@ void CIO::Init()
 
 #if defined(PI_HAT_7021_REV_02)
   GPIO_PinRemapConfig(GPIO_Remap_SWJ_Disable, ENABLE);
-#elif defined(ZUMSPOT_ADF7021) || defined(LIBRE_KIT_ADF7021) || defined(MMDVM_HS_HAT_REV12) || defined(MMDVM_HS_DUAL_HAT_REV10) || defined(NANO_HOTSPOT) || defined(NANO_DV_REV11) || defined(D2RG_MMDVM_HS) || defined(SKYBRIDGE_HS)
+#elif defined(ZUMSPOT_ADF7021) || defined(LONESTAR_USB) || defined(LIBRE_KIT_ADF7021) || defined(MMDVM_HS_HAT_REV12) || defined(MMDVM_HS_DUAL_HAT_REV10) || defined(NANO_HOTSPOT) || defined(NANO_DV_REV11) || defined(D2RG_MMDVM_HS) || defined(SKYBRIDGE_HS)
   GPIO_PinRemapConfig(GPIO_Remap_SWJ_JTAGDisable, ENABLE);
 #endif
 
-#if defined(ZUMSPOT_ADF7021) || defined(SKYBRIDGE_HS)
+#if defined(ZUMSPOT_ADF7021) || defined(LONESTAR_USB) || defined(SKYBRIDGE_HS)
   // Pin defines if the board has a single ADF7021 or double
   GPIO_InitStruct.GPIO_Speed = GPIO_Speed_50MHz;
   GPIO_InitStruct.GPIO_Pin   = PIN_SGL_DBL;
@@ -549,7 +549,7 @@ void CIO::Init()
   EXTI_InitStructure.EXTI_Line = EXTI_Line14;
 #endif
 
-#elif defined(ZUMSPOT_ADF7021) || defined(LIBRE_KIT_ADF7021) || defined(MMDVM_HS_HAT_REV12) || defined(MMDVM_HS_DUAL_HAT_REV10) || defined(NANO_HOTSPOT) || defined(NANO_DV_REV11) || defined(D2RG_MMDVM_HS) || defined(SKYBRIDGE_HS)
+#elif defined(ZUMSPOT_ADF7021) || defined(LONESTAR_USB) || defined(LIBRE_KIT_ADF7021) || defined(MMDVM_HS_HAT_REV12) || defined(MMDVM_HS_DUAL_HAT_REV10) || defined(NANO_HOTSPOT) || defined(NANO_DV_REV11) || defined(D2RG_MMDVM_HS) || defined(SKYBRIDGE_HS)
 
 #if defined(BIDIR_DATA_PIN)
   // Connect EXTI3 Line
@@ -567,7 +567,7 @@ void CIO::Init()
   // Connect EXTI5 Line
   GPIO_EXTILineConfig(PORT_TXD2_INT, PIN_TXD2_INT);
   // Configure EXT5 line
-  #if defined(ZUMSPOT_ADF7021) || defined(SKYBRIDGE_HS)
+  #if defined(ZUMSPOT_ADF7021) || defined(LONESTAR_USB) || defined(SKYBRIDGE_HS)
   EXTI_InitStructure2.EXTI_Line = EXTI_Line8;
   #else
   EXTI_InitStructure2.EXTI_Line = EXTI_Line5;
@@ -601,7 +601,7 @@ void CIO::startInt()
 
   NVIC_InitStructure.NVIC_IRQChannel = EXTI15_10_IRQn;
 
-#elif defined(ZUMSPOT_ADF7021) || defined(LIBRE_KIT_ADF7021) || defined(MMDVM_HS_HAT_REV12) || defined(MMDVM_HS_DUAL_HAT_REV10) || defined(NANO_HOTSPOT) || defined(NANO_DV_REV11) || defined(D2RG_MMDVM_HS) || defined(SKYBRIDGE_HS)
+#elif defined(ZUMSPOT_ADF7021) || defined(LONESTAR_USB) || defined(LIBRE_KIT_ADF7021) || defined(MMDVM_HS_HAT_REV12) || defined(MMDVM_HS_DUAL_HAT_REV10) || defined(NANO_HOTSPOT) || defined(NANO_DV_REV11) || defined(D2RG_MMDVM_HS) || defined(SKYBRIDGE_HS)
 
 #if defined(BIDIR_DATA_PIN)
   // Enable and set EXTI3 Interrupt
@@ -781,7 +781,7 @@ void CIO::COS_pin(bool on)
   GPIO_WriteBit(PORT_COS_LED, PIN_COS_LED, on ? Bit_SET : Bit_RESET);
 }
 
-#if defined(ZUMSPOT_ADF7021) || defined(SKYBRIDGE_HS)
+#if defined(ZUMSPOT_ADF7021) || defined(LONESTAR_USB) || defined(SKYBRIDGE_HS)
 void CIO::setBandVHF(bool vhf_on) {
   GPIO_WriteBit(PORT_SET_BAND, PIN_SET_BAND, vhf_on ? Bit_SET : Bit_RESET);
 }

--- a/SerialPort.cpp
+++ b/SerialPort.cpp
@@ -333,7 +333,7 @@ uint8_t CSerialPort::setConfig(const uint8_t* data, uint8_t length)
     DEBUG1("Full duplex not supported with this firmware");
     return 6U;
   }
-#elif defined(DUPLEX) && (defined(ZUMSPOT_ADF7021) || defined(SKYBRIDGE_HS))
+#elif defined(DUPLEX) && (defined(ZUMSPOT_ADF7021) || defined(LONESTAR_USB) || defined(SKYBRIDGE_HS))
   if (io.isDualBand() && m_duplex && m_calState == STATE_IDLE && modemState != STATE_DSTARCAL) {
     DEBUG1("Full duplex is not supported on this board");
     return 6U;

--- a/configs/LoneStar_USB.h
+++ b/configs/LoneStar_USB.h
@@ -23,7 +23,7 @@
 // 1) ZUMspot RPi or ZUMspot USB:
 // #define ZUMSPOT_ADF7021
 // 2) Libre Kit board or any homebrew hotspot with modified RF7021SE and Blue Pill STM32F103:
-#define LIBRE_KIT_ADF7021
+// #define LIBRE_KIT_ADF7021
 // 3) MMDVM_HS_Hat revisions 1.1, 1.2 and 1.4 (DB9MAT & DF2ET)
 // #define MMDVM_HS_HAT_REV12
 // 4) MMDVM_HS_Dual_Hat revisions 1.0 (DB9MAT & DF2ET & DO7EN)
@@ -37,7 +37,7 @@
 // 8) BridgeCom SkyBridge HotSpot
 // #define SKYBRIDGE_HS
 // 9) LoneStar USB Stick ADF7071
-// #define LONESTAR_USB
+#define LONESTAR_USB
 
 // Enable ADF7021 support:
 #define ENABLE_ADF7021
@@ -73,11 +73,10 @@
 #define ENABLE_SCAN_MODE
 
 // Send RSSI value:
-// #define SEND_RSSI_DATA
+#define SEND_RSSI_DATA
 
 // Enable Nextion LCD serial port repeater on USART2 (ZUMspot Libre Kit and ZUMspot RPi):
-#define SERIAL_REPEATER
-#define SERIAL_REPEATER_BAUD 9600
+// #define SERIAL_REPEATER
 
 // Enable Nextion LCD serial port repeater on USART1 (Do not use with STM32_USART1_HOST enabled):
 // #define SERIAL_REPEATER_USART1

--- a/scripts/build_fw.sh
+++ b/scripts/build_fw.sh
@@ -176,4 +176,13 @@ make -j4
 mv ~/MMDVM_HS/bin/mmdvm_f1.bin ~/MMDVM_HS/bin/skybridge_rpi_fw.bin
 make clean
 
+# Building LoneStar USB
+echo "*************************************************"
+echo "********* Building LoneStar USB firmware *********"
+echo "*************************************************"
+cp ~/MMDVM_HS/configs/LoneStar_USB.h ~/MMDVM_HS/Config.h
+make -j4 bl
+mv ~/MMDVM_HS/bin/mmdvm_f1bl.bin ~/MMDVM_HS/bin/lonestar_usb_fw.bin
+make clean
+
 cp ~/MMDVM_HS/configs/ZUMspot_Libre.h ~/MMDVM_HS/Config.h

--- a/scripts/install_fw_lonestar_usb.sh
+++ b/scripts/install_fw_lonestar_usb.sh
@@ -1,0 +1,95 @@
+#!/bin/bash
+
+#   Copyright (C) 2017,2018 by Andy Uribe CA6JAU
+
+#   This program is free software; you can redistribute it and/or modify
+#   it under the terms of the GNU General Public License as published by
+#   the Free Software Foundation; either version 2 of the License, or
+#   (at your option) any later version.
+#
+#   This program is distributed in the hope that it will be useful,
+#   but WITHOUT ANY WARRANTY; without even the implied warranty of
+#   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#   GNU General Public License for more details.
+#
+#   You should have received a copy of the GNU General Public License
+#   along with this program; if not, write to the Free Software
+#   Foundation, Inc., 675 Mass Ave, Cambridge, MA 02139, USA.
+
+# Configure latest version
+FW_VERSION="v1.6.0"
+
+# Change USB-serial port name ONLY in macOS
+MAC_DEV_USB_SER="/dev/cu.usbmodem14401"
+
+# Configure beta version
+FW_VERSION_BETA="v1.6.0b"
+
+# Firmware filename
+FW_FILENAME="lonestar_usb_fw.bin"
+	
+# Download latest firmware
+if [ $1 = "beta" ]; then
+	echo "Downloading beta firmware..."
+	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION_BETA/$FW_FILENAME
+else
+	echo "Downloading latest firmware (stable)..."
+	curl -OL https://github.com/juribeparada/MMDVM_HS/releases/download/$FW_VERSION/$FW_FILENAME
+fi
+
+# Download STM32F10X_Lib (only for binary tools)
+if [ ! -d "./STM32F10X_Lib/utils" ]; then
+  git clone https://github.com/juribeparada/STM32F10X_Lib
+fi
+
+# Configure vars depending on OS
+if [ $(uname -s) == "Linux" ]; then
+	DEV_USB_SER="/dev/ttyACM0"
+	if [ $(uname -m) == "x86_64" ]; then
+		echo "Linux 64-bit detected"
+		DFU_RST="./STM32F10X_Lib/utils/linux64/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/linux64/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/linux64/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/linux64/stm32flash"
+	elif [ $(uname -m) == "armv7l" ]; then
+		echo "Raspberry Pi 3 detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
+	elif [ $(uname -m) == "armv6l" ]; then
+		echo "Raspberry Pi 2 or Pi Zero W detected"
+		DFU_RST="./STM32F10X_Lib/utils/rpi32/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/rpi32/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/rpi32/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/rpi32/stm32flash"
+	else
+		echo "Linux 32-bit detected"
+		DFU_RST="./STM32F10X_Lib/utils/linux/upload-reset"
+		DFU_UTIL="./STM32F10X_Lib/utils/linux/dfu-util"
+		ST_FLASH="./STM32F10X_Lib/utils/linux/st-flash"
+		STM32FLASH="./STM32F10X_Lib/utils/linux/stm32flash"
+	fi
+fi
+
+if [ $(uname -s) == "Darwin" ]; then
+	echo "macOS detected"
+	DEV_USB_SER=$MAC_DEV_USB_SER
+	DFU_RST="./STM32F10X_Lib/utils/macosx/upload-reset"
+	DFU_UTIL="./STM32F10X_Lib/utils/macosx/dfu-util"
+	ST_FLASH="./STM32F10X_Lib/utils/macosx/st-flash"
+	STM32FLASH="./STM32F10X_Lib/utils/macosx/stm32flash"
+fi
+
+# Stop MMDVMHost process to free serial port
+sudo killall MMDVMHost >/dev/null 2>&1
+
+# Reset ZUMspot to enter bootloader mode
+eval sudo $DFU_RST $DEV_USB_SER 750
+
+# Upload the firmware
+eval sudo $DFU_UTIL -D $FW_FILENAME -d 1eaf:0003 -a 2 -R -R
+
+echo
+echo "Please RESET your LoneStar device !"
+echo

--- a/version.h
+++ b/version.h
@@ -42,6 +42,8 @@
 #define BOARD_INFO      "D2RG_MMDVM_HS"
 #elif defined(SKYBRIDGE_HS)
 #define BOARD_INFO      "SkyBridge"
+#elif defined(LONESTAR_USB)
+#define BOARD_INFO      "LS_USB_STICK"
 #else
 #define BOARD_INFO      "MMDVM_HS"
 #endif


### PR DESCRIPTION
Functionally equivalent to the ZUM USB, this just gives the LoneStar its own version string. 