### PR TITLE
Add `BOARD_INFO` type string ("MMDVM_HS_Dual_Hat") for `MMDVM_HS_HAT_REV12` boards with `DUPLEX` defined.

### DIFF
--- a/version.h
+++ b/version.h
@@ -25,12 +25,14 @@
 
 #define VER_MAJOR       "1"
 #define VER_MINOR       "6"
-#define VER_REV         "0"
-#define VERSION_DATE    "20210919"
+#define VER_REV         "1"
+#define VERSION_DATE    "20230201"
 
 #if defined(ZUMSPOT_ADF7021)
 #define BOARD_INFO      "ZUMspot"
-#elif defined(MMDVM_HS_HAT_REV12)
+#elif defined(MMDVM_HS_HAT_REV12) && defined(DUPLEX)
+#define BOARD_INFO      "MMDVM_HS_Dual_Hat"
+#elif defined(MMDVM_HS_HAT_REV12) && !defined(DUPLEX)
 #define BOARD_INFO      "MMDVM_HS_Hat"
 #elif defined(MMDVM_HS_DUAL_HAT_REV10)
 #define BOARD_INFO      "MMDVM_HS_Dual_Hat"


### PR DESCRIPTION
We've been seeing a recent influx of generic `MMDVM_HS_HAT_REV12`-type boards surface, which are dual-HAT/duplex capable. However, even when `#define DUPLEX` is defined by the user, the `BOARD_INFO` type string is `MMDVM_HS_Hat`.

This PR introduces minor logic to report these configurations as `MMDVM_HS_Dual_Hat`...

When the user defines `#define DUPLEX` along with `#define MMDVM_HS_HAT_REV12` in their `Config.h`, the `version.h` logic will then define the board type string as `#define BOARD_INFO "MMDVM_HS_Dual_Hat"`.

This change will provide for more accurate board string identifiers used by `MMDVMhost`, `W0CHP-PiStar-Dash` and other related software.