### PR TITLE
Update P25RX.cpp

### DIFF
--- a/P25RX.cpp
+++ b/P25RX.cpp
@@ -69,6 +69,7 @@ void CP25RX::databit(bool bit)
       processNone(bit);
       break;
   }
+  io.setDecode(m_state != P25RXS_NONE);
 }
 
 void CP25RX::processNone(bool bit)


### PR DESCRIPTION
Resolve the issue where, in standalone P25 mode, the COS LED remains constantly lit after the hotspot receives a P25 signal.