### PR TITLE
Reduce Hardcoded P25 TX Delay

### DIFF
--- a/P25TX.cpp
+++ b/P25TX.cpp
@@ -30,7 +30,7 @@ m_buffer(1500U),
 m_poBuffer(),
 m_poLen(0U),
 m_poPtr(0U),
-m_txDelay(240U),      // 200ms
+m_txDelay(60U),       // 50ms (reduced for TPT support)
 m_delay(false)
 {
 }
@@ -111,7 +111,7 @@ void CP25TX::writeByte(uint8_t c)
 
 void CP25TX::setTXDelay(uint8_t delay)
 {
-  m_txDelay = 600U + uint16_t(delay) * 12U;        // 500ms + tx delay
+  m_txDelay = 60U + uint16_t(delay) * 12U;         // 50ms + tx delay (reduced for TPT support)
 }
 
 uint16_t CP25TX::getSpace() const


### PR DESCRIPTION
- Reduced hardcoded minimum TX delay from 200ms/500ms to 50/50ms to allow for quick responses. Specifically, this is required to support features such as Talk-permit tone on Motorola radios (ie. APX radios), which require a voice grant packet to be sent quickly. This feature is now supported in the MMDVMHost project.