### PR TITLE
Fix TXSerialFlush1/2 so they actually wait for transmission to complete

### DIFF
--- a/SerialSTM.cpp
+++ b/SerialSTM.cpp
@@ -103,8 +103,12 @@ uint16_t RXSerialfifolevel1()
 // warning: this call is blocking
 void TXSerialFlush1()
 {
-  // wait until the TXE shows the shift register is empty
-  while (USART_GetITStatus(USART1, USART_FLAG_TXE))
+  // wait until the TX FIFO has drained
+  while (TXSerialfifolevel1() > 0U)
+    ;
+
+  // wait until the TC flag shows the shift register is empty
+  while (USART_GetFlagStatus(USART1, USART_FLAG_TC) == RESET)
     ;
 }
 
@@ -294,8 +298,12 @@ uint16_t RXSerialfifolevel2()
 // warning: this call is blocking
 void TXSerialFlush2()
 {
-  // wait until the TXE shows the shift register is empty
-  while (USART_GetITStatus(USART2, USART_FLAG_TXE))
+  // wait until the TX FIFO has drained
+  while (TXSerialfifolevel2() > 0U)
+    ;
+
+  // wait until the TC flag shows the shift register is empty
+  while (USART_GetFlagStatus(USART2, USART_FLAG_TC) == RESET)
     ;
 }
 


### PR DESCRIPTION
Both `TXSerialFlush1()` and `TXSerialFlush2()` pass a flag constant (`USART_FLAG_TXE`) to `USART_GetITStatus()` and spin *while* TXE is set — but TXE being set means the transmit data register is already empty, so the loop exits immediately while data is still queued in the software FIFO and shifting out of the USART. In other words, flush never waited at all.

This matters for the `writeInt(..., flush = true)` call sites (the debug writers and the Nextion serial-repeater forwarding), where the intent is to guarantee the bytes have fully left before continuing.

The fix waits for the software TX FIFO to drain (the FIFO indices are already `volatile`) and then for the TC flag, which indicates the shift register has genuinely emptied.

The same inherited bug in the MMDVM repeater firmware's `CSTMUART::flush()` was recently fixed the same way (g4klx/MMDVM#359).

Build-tested with GCC 14.2.1 (`make hs`) and runtime-tested on an MMDVM_HS_Dual_Hat rev 1.0.